### PR TITLE
Fixed up date formatting

### DIFF
--- a/app/models/consumable_type.rb
+++ b/app/models/consumable_type.rb
@@ -11,7 +11,7 @@ class ConsumableType < ActiveRecord::Base
   alias_attribute :ingredients, :parents
 
   def expiry_date_from_today
-    Date.today.advance(days: days_to_keep).to_date.to_s(:uk) if days_to_keep.present?
+    Date.today.advance(days: days_to_keep).to_s(:uk) if days_to_keep.present?
   end
 
   def latest_consumables

--- a/config/initializers/01_Integer.rb
+++ b/config/initializers/01_Integer.rb
@@ -1,7 +1,0 @@
-class Integer
-
-  def days_from_today
-    self.days.from_now.to_date.to_s(:uk)
-  end
-
-end

--- a/config/initializers/date_and_time_formats.rb
+++ b/config/initializers/date_and_time_formats.rb
@@ -1,3 +1,5 @@
+# Datetime / Time
 Time::DATE_FORMATS[:uk] = '%A %B %e %Y %H:%M'
-Date::DATE_FORMATS[:uk] = '%d %B %Y'
-DateTime::DATE_FORMATS[:uk] = '%d/%m/%Y'
+
+# Date
+Date::DATE_FORMATS[:uk] = '%d/%m/%Y'

--- a/spec/models/consumable_type_spec.rb
+++ b/spec/models/consumable_type_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe ConsumableType, type: :model do
     expect(consumable_type.expiry_date_from_today).to be_nil
 
     consumable_type = build(:consumable_type)
-    expect(consumable_type.expiry_date_from_today).to eq(consumable_type.days_to_keep.days_from_today)
+    expect(consumable_type.expiry_date_from_today).to eq((Date.today + consumable_type.days_to_keep).to_s(:uk))
   end
 
   it "should be able to have one child" do


### PR DESCRIPTION
Apparently Time::DATE_FORMATS speaks for Time as well
as Date objects, so changed the initializer to reflect
this.

Removed the Interger monkey patch as it was no longer
necessary.