### PR TITLE
Altered supplier validation

### DIFF
--- a/app/models/kitchen.rb
+++ b/app/models/kitchen.rb
@@ -7,5 +7,7 @@ class Kitchen < ActiveRecord::Base
   has_many :ingredients
 
   validates_presence_of :name
-  validates :name, uniqueness: { case_sensitive: false }
+  validates :product_code, uniqueness: { case_sensitive: false }, if: -> { product_code.present? }
+
+  validates :name, uniqueness: { case_sensitive: false, scope: :product_code }
 end

--- a/db/migrate/20181016142937_add_product_code_index_to_kitchen.rb
+++ b/db/migrate/20181016142937_add_product_code_index_to_kitchen.rb
@@ -1,0 +1,5 @@
+class AddProductCodeIndexToKitchen < ActiveRecord::Migration[5.2]
+  def change
+    add_index :kitchens, :product_code, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,11 +10,11 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_10_09_112244) do
+ActiveRecord::Schema.define(version: 2018_10_16_142937) do
 
   create_table "audits", force: :cascade do |t|
-    t.integer "auditable_id"
     t.string "auditable_type"
+    t.integer "auditable_id"
     t.integer "user_id"
     t.string "action"
     t.string "record_data"
@@ -75,6 +75,7 @@ ActiveRecord::Schema.define(version: 2018_10_09_112244) do
     t.string "type"
     t.boolean "active", default: true, null: false
     t.string "product_code"
+    t.index ["product_code"], name: "index_kitchens_on_product_code", unique: true
   end
 
   create_table "label_types", force: :cascade do |t|

--- a/spec/models/kitchen_spec.rb
+++ b/spec/models/kitchen_spec.rb
@@ -3,18 +3,31 @@ require Rails.root.join 'spec/models/concerns/activatable.rb'
 
 RSpec.describe Kitchen, type: :model do
   it "should not be valid without a name" do
-    expect(build(:kitchen, name: nil)).to_not be_valid
+    expect(build(:kitchen, name: nil)).not_to be_valid
+    expect(build(:kitchen, name: '')).not_to be_valid
   end
 
-  it "should not allow duplicate names" do
-    kitchen = create(:kitchen)
-    expect(build(:kitchen, name: kitchen.name)).to_not be_valid
+  it "should not allow duplicate names without product codes" do
+    kitchen = create(:kitchen, name: 'xyz')
+    expect(build(:kitchen, name: 'XYZ')).not_to be_valid
   end
 
-  it "should not allow duplicate names with differing case" do
-    kitchen = create(:kitchen)
-    expect(build(:kitchen, name: kitchen.name.upcase)).to_not be_valid
-    expect(build(:kitchen, name: kitchen.name.downcase)).to_not be_valid
+  it "should allow duplicate names with different product codes" do
+    kitchen1 = create(:kitchen, name: 'alpha', product_code: 'xyz')
+    kitchen2 = create(:kitchen, name: 'alpha', product_code: 'abc')
+    expect(build(:kitchen, name: 'alpha', product_code: 'rst')).to be_valid
+  end
+
+  it 'should allow multiple kitchens without a product code' do
+    kitchen1 = create(:kitchen, product_code: nil)
+    kitchen2 = create(:kitchen, product_code: nil)
+    expect(build(:kitchen, product_code: nil)).to be_valid
+  end
+
+  it 'should not allow multiple kitchens with the same product code' do
+    kitchen = create(:kitchen, product_code: 'Xyz')
+    expect(build(:kitchen, product_code: 'xyz')).not_to be_valid
+    expect(build(:kitchen, product_code: 'XYZ')).not_to be_valid
   end
 
   it_behaves_like "activatable"


### PR DESCRIPTION
Added unique index on kitchen.product_code.
Disallow two kitchens with the same product code.
Disallow two kitchens with the same name and no product code.
Allow two kitchens with the same name and different product codes.
Allow multiple kitchens with no product code.