### PR TITLE
Put pmb ids in config overruling the external_id in the database

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -79,4 +79,6 @@ Rails.application.configure do
   config.enable_snow = true
   config.snow_start = 'Dec 11'
   config.snow_end = 'Dec 30'
+
+  config.pmb_id = { 1 => 226, 2 => 227 }
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -118,6 +118,5 @@ Rails.application.configure do
   # config.active_record.database_resolver = ActiveRecord::Middleware::DatabaseSelector::Resolver
   # config.active_record.database_resolver_context = ActiveRecord::Middleware::DatabaseSelector::Resolver::Session
 
-  # TODO: change this when we create the new templates on prod pmb
-  config.pmb_id = { 1 => 2, 2 => 3 }
+  config.pmb_id = { 1 => 42, 2 => 43 }
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -117,4 +117,7 @@ Rails.application.configure do
   # config.active_record.database_selector = { delay: 2.seconds }
   # config.active_record.database_resolver = ActiveRecord::Middleware::DatabaseSelector::Resolver
   # config.active_record.database_resolver_context = ActiveRecord::Middleware::DatabaseSelector::Resolver::Session
+
+  # TODO: change this when we create the new templates on prod pmb
+  config.pmb_id = { 1 => 2, 2 => 3 }
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -54,4 +54,6 @@ Rails.application.configure do
     }
 
   config.enable_snow = false
+
+  config.pmb_id = { 1 => 226, 2 => 227 }
 end

--- a/lib/print_job.rb
+++ b/lib/print_job.rb
@@ -23,11 +23,15 @@ class PrintJob
     end
   end
 
+  def label_to_pmb_id(label_type_id)
+    Rails.configuration.try(:pmb_id).to_h[label_type_id] || LabelType.find(label_type_id).external_id
+  end
+
   def execute!
     return false unless valid?
 
     # Find the label type's external ID for use with PMB
-    pmb_template_id = LabelType.find(label_type_id).external_id
+    pmb_template_id = label_to_pmb_id(label_type_id)
 
     begin
       PMB::PrintJob.execute(printer_name: printer, label_template_id: pmb_template_id, labels: labels.to_h)

--- a/spec/lib/print_job_spec.rb
+++ b/spec/lib/print_job_spec.rb
@@ -13,8 +13,9 @@ RSpec.describe PrintJob, type: :model do
 
   it "should return true when a print job executes successfully" do
     labels = Labels.new(@batch).to_h
+    template_id = Rails.configuration.pmb_id[@label_type.id] || 1
     expect(PMB::PrintJob).to receive(:execute)
-      .with(printer_name: @printer.name, label_template_id: @label_type.id, labels: labels)
+      .with(printer_name: @printer.name, label_template_id: template_id, labels: labels)
       .and_return(true)
     expect(@print_job.execute!).to eq(true)
   end


### PR DESCRIPTION
Having pmb template ids in the external_id column in label_types is awkward
because the template id is different depending on which instance of pmb is
being used (which is dependant on environment).
So add config to specify the pmb template ids, overruling the external_id
column (if present). The template ids in the production config must be
filled in once those templates are created on production pmb.