### PR TITLE
Bugfix webdrivers

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -60,7 +60,7 @@ end
 
 group :test do
   gem 'capybara'
-  gem 'selenium-webdriver', '< 4.10.0', require: false
+  gem 'selenium-webdriver', '<= 4.9.0', require: false
   gem 'database_cleaner'
   gem 'rake'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -60,7 +60,7 @@ end
 
 group :test do
   gem 'capybara'
-  gem 'selenium-webdriver', '~> 4.6', require: false
+  gem 'selenium-webdriver', '~> 4.1', require: false
   gem 'database_cleaner'
   gem 'rake'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -60,7 +60,7 @@ end
 
 group :test do
   gem 'capybara'
-  gem 'selenium-webdriver', '~> 4.1', require: false
+  gem 'selenium-webdriver', '< 4.10.0', require: false
   gem 'database_cleaner'
   gem 'rake'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -60,7 +60,7 @@ end
 
 group :test do
   gem 'capybara'
-  gem 'selenium-webdriver', '~> 4.1', require: false
+  gem 'selenium-webdriver', '~> 4.6', require: false
   gem 'database_cleaner'
   gem 'rake'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -60,7 +60,7 @@ end
 
 group :test do
   gem 'capybara'
-  gem 'webdrivers', '~> 4.0', require: false
+  gem 'selenium-webdriver', '~> 4.1', require: false
   gem 'database_cleaner'
   gem 'rake'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -265,7 +265,7 @@ GEM
       sprockets (> 3.0)
       sprockets-rails
       tilt
-    selenium-webdriver (4.11.0)
+    selenium-webdriver (4.9.1)
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
@@ -336,7 +336,7 @@ DEPENDENCIES
   raml_ruby
   rspec-rails
   sass-rails
-  selenium-webdriver (~> 4.1)
+  selenium-webdriver (< 4.10.0)
   spring
   therubyracer
   turbolinks

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -265,7 +265,7 @@ GEM
       sprockets (> 3.0)
       sprockets-rails
       tilt
-    selenium-webdriver (4.9.1)
+    selenium-webdriver (4.9.0)
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
@@ -336,7 +336,7 @@ DEPENDENCIES
   raml_ruby
   rspec-rails
   sass-rails
-  selenium-webdriver (< 4.10.0)
+  selenium-webdriver (<= 4.9.0)
   spring
   therubyracer
   turbolinks

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -336,7 +336,7 @@ DEPENDENCIES
   raml_ruby
   rspec-rails
   sass-rails
-  selenium-webdriver (~> 4.6)
+  selenium-webdriver (~> 4.1)
   spring
   therubyracer
   turbolinks

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -94,7 +94,6 @@ GEM
       xpath (~> 3.2)
     case_transform (0.2)
       activesupport
-    childprocess (3.0.0)
     coffee-rails (5.0.0)
       coffee-script (>= 2.2.0)
       railties (>= 5.2.0)
@@ -236,6 +235,7 @@ GEM
       ffi (~> 1.0)
     ref (2.0.0)
     regexp_parser (2.1.1)
+    rexml (3.2.6)
     rspec-core (3.10.1)
       rspec-support (~> 3.10.0)
     rspec-expectations (3.10.1)
@@ -254,7 +254,7 @@ GEM
       rspec-support (~> 3.10)
     rspec-support (3.10.2)
     ruby2_keywords (0.0.4)
-    rubyzip (2.3.0)
+    rubyzip (2.3.2)
     sass-rails (6.0.0)
       sassc-rails (~> 2.1, >= 2.1.1)
     sassc (2.4.0)
@@ -265,9 +265,10 @@ GEM
       sprockets (> 3.0)
       sprockets-rails
       tilt
-    selenium-webdriver (3.142.7)
-      childprocess (>= 0.5, < 4.0)
-      rubyzip (>= 1.2.2)
+    selenium-webdriver (4.11.0)
+      rexml (~> 3.2, >= 3.2.5)
+      rubyzip (>= 1.2.2, < 3.0)
+      websocket (~> 1.0)
     spring (2.1.1)
     sprockets (4.0.2)
       concurrent-ruby (~> 1.0)
@@ -294,10 +295,7 @@ GEM
       activemodel (>= 6.0.0)
       bindex (>= 0.4.0)
       railties (>= 6.0.0)
-    webdrivers (4.6.0)
-      nokogiri (~> 1.6)
-      rubyzip (>= 1.3.0)
-      selenium-webdriver (>= 3.0, < 4.0)
+    websocket (1.2.9)
     websocket-driver (0.7.3)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
@@ -338,13 +336,13 @@ DEPENDENCIES
   raml_ruby
   rspec-rails
   sass-rails
+  selenium-webdriver (~> 4.6)
   spring
   therubyracer
   turbolinks
   uglifier
   web-console
-  webdrivers (~> 4.0)
   with_model
 
 BUNDLED WITH
-   2.1.4
+   2.3.18

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -5,7 +5,6 @@ require File.expand_path('../../config/environment', __FILE__)
 require 'rspec/rails'
 
 require 'with_model'
-require 'webdrivers/chromedriver'
 
 # Add additional requires below this line. Rails is not loaded until this point!
 


### PR DESCRIPTION
Closes #

Changes proposed in this pull request:

- Replaced web drivers with selenium-webdrivers. The highest supported version is 4.9.0 for ruby 2.7 .
- See https://stackoverflow.com/questions/76562584/unable-to-find-the-latest-chrome-driver-114-0-5735-134 . Selenium web driver should fetch the correct chrome driver.


#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check version_  
